### PR TITLE
Configurable BPF probe rate curve

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,12 @@
 ---
 linters:
-  enable-all: true
+  presets:
+    - unused
+    - performance
+    - format
+    - complexity
+    - bugs
+
   disable:
     - gochecknoinits
     - gochecknoglobals

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -19,12 +19,32 @@ var (
 	cfgPProfEndpoint = "pprof_endpoint"
 
 	cfgSinks = "sinks"
+	cfgProbe = "probe"
+
+	cfgProbeRateCurve = "rate_curve"
 
 	// Default application configuration.
 	cfgDefaults = map[string]interface{}{
 		// HTTP API endpoint.
 		cfgAPIEnabled:  true,
 		cfgAPIEndpoint: "localhost:8000",
+
+		cfgProbe: map[string]interface{}{
+			cfgProbeRateCurve: map[string]interface{}{
+				"1": map[string]interface{}{
+					"age":  "0",
+					"rate": "20s",
+				},
+				"2": map[string]interface{}{
+					"age":  "60s",
+					"rate": "60s",
+				},
+				"3": map[string]interface{}{
+					"age":  "5m",
+					"rate": "5m",
+				},
+			},
+		},
 
 		// Sinks for accounting data.
 		cfgSinks: map[string]interface{}{

--- a/configs/conntracct.yml
+++ b/configs/conntracct.yml
@@ -5,6 +5,25 @@
 api_enabled: true
 api_endpoint: "localhost:8000"
 
+# Accounting probe configuration.
+probe:
+  # Update rate interval. rate_curve has 3 configurable curve points.
+  #
+  # When a flow is older than the age of the first curve point, it will send updates
+  # at the configured rate. In this example, all flows start out at one event per 20 seconds.
+  # Once it reaches the age of the next curve point (60 seconds), it will send updates
+  # once every 60 seconds, etc.
+  rate_curve:
+    0:
+      age: 0
+      rate: 20s
+    1:
+      age: 60s
+      rate: 60s
+    2:
+      age: 5m
+      rate: 5m
+
 # Data Sinks (outputs)
 sinks:
   influxdb_udp:

--- a/internal/config/probe_config.go
+++ b/internal/config/probe_config.go
@@ -1,0 +1,70 @@
+package config
+
+import (
+	"time"
+
+	"github.com/mitchellh/mapstructure"
+
+	"github.com/ti-mo/conntracct/pkg/bpf"
+)
+
+// ProbeConfig represents the configuration of an accounting probe.
+type ProbeConfig struct {
+	// Probe Rate Curve structure.
+	RateCurve ProbeConfigCurve `mapstructure:"rate_curve"`
+}
+
+// ProbeConfigCurve is the probe's rate curve configuration.
+type ProbeConfigCurve struct {
+	Zero ProbeConfigCurvePoint `mapstructure:"0"`
+	One  ProbeConfigCurvePoint `mapstructure:"1"`
+	Two  ProbeConfigCurvePoint `mapstructure:"2"`
+}
+
+// ProbeConfigCurvePoint is an age/rate point in the probe's rate curve.
+type ProbeConfigCurvePoint struct {
+	// The age a flow must have to be affected by this rate.
+	Age time.Duration `mapstructure:"age"`
+	// The update rate of the flow.
+	Rate time.Duration `mapstructure:"rate"`
+}
+
+// DecodeProbeConfigMap extracts ProbeConfig from configuration data.
+func DecodeProbeConfigMap(cfg map[string]interface{}) (*ProbeConfig, error) {
+
+	var out ProbeConfig
+
+	d, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		DecodeHook: mapstructure.StringToTimeDurationHookFunc(),
+		Result:     &out,
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	// Decode sink configuration map into SinkConfig.
+	if err := d.Decode(cfg); err != nil {
+		return nil, err
+	}
+
+	return &out, nil
+}
+
+// BPFConfig extracts a pkg/bpf.Config from a ProbeConfig
+func (pc *ProbeConfig) BPFConfig() bpf.Config {
+
+	return bpf.Config{
+		Curve0: bpf.CurvePoint{
+			Age:  pc.RateCurve.Zero.Age,
+			Rate: pc.RateCurve.Zero.Rate,
+		},
+		Curve1: bpf.CurvePoint{
+			Age:  pc.RateCurve.One.Age,
+			Rate: pc.RateCurve.One.Rate,
+		},
+		Curve2: bpf.CurvePoint{
+			Age:  pc.RateCurve.Two.Age,
+			Rate: pc.RateCurve.Two.Rate,
+		},
+	}
+}

--- a/internal/pprof/pprof.go
+++ b/internal/pprof/pprof.go
@@ -6,7 +6,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	// side effect of registering HTTP handler in default ServeMux
-	_ "net/http/pprof"
+	_ "net/http/pprof" //nolint:gosec
 )
 
 // ListenAndServe starts a pprof endpoint on the given addr

--- a/pkg/bpf/integration_test.go
+++ b/pkg/bpf/integration_test.go
@@ -34,16 +34,16 @@ func TestMain(m *testing.M) {
 
 	cfg := Config{
 		Curve0: CurvePoint{
-			AgeMillis:      0,
-			IntervalMillis: 10,
+			Age:  0 * time.Millisecond,
+			Rate: 10 * time.Millisecond,
 		},
 		Curve1: CurvePoint{
-			AgeMillis:      50,
-			IntervalMillis: 25,
+			Age:  50 * time.Millisecond,
+			Rate: 25 * time.Millisecond,
 		},
 		Curve2: CurvePoint{
-			AgeMillis:      100,
-			IntervalMillis: 50,
+			Age:  100 * time.Millisecond,
+			Rate: 50 * time.Millisecond,
 		},
 	}
 


### PR DESCRIPTION
- Rate curve is now configurable by the user
- Switch to `time.Duration` for representing probe rate curves internally
- Disable some linters (wsl..) in new golangci-lint release