### PR TITLE
Run integration tests in network namespaces

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,24 +4,26 @@ go 1.12
 
 require (
 	github.com/blang/semver v3.5.1+incompatible
-	github.com/gogo/protobuf v1.2.0 // indirect
+	github.com/google/nftables v0.0.0-20191115091743-3ba45f5d7848
 	github.com/gorilla/mux v1.7.0
 	github.com/influxdata/influxdb v1.7.4
 	github.com/influxdata/platform v0.0.0-20190117200541-d500d3cf5589 // indirect
 	github.com/iovisor/gobpf v0.0.0-20190311163924-89fd87167a6e
+	github.com/jsimonetti/rtnetlink v0.0.0-20190606172950-9527aa82566a
 	github.com/lorenzosaino/go-sysctl v0.1.0
 	github.com/magefile/mage v1.8.0
+	github.com/mdlayher/netlink v0.0.0-20191009155606-de872b0d824b
 	github.com/mitchellh/go-homedir v1.0.0
 	github.com/mitchellh/mapstructure v1.1.2
 	github.com/olivere/elastic/v7 v7.0.9
 	github.com/pkg/errors v0.8.1
-	github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829 // indirect
 	github.com/rakyll/statik v0.1.6
 	github.com/sirupsen/logrus v1.4.0
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/viper v1.3.2
 	github.com/stretchr/testify v1.2.2
 	github.com/ti-mo/kconfig v0.0.0-20181208153747-0708bf82969f
+	github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df
 	golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6
-	golang.org/x/sys v0.0.0-20190502145724-3ef323f4f1fd
+	golang.org/x/sys v0.0.0-20191029155521-f43be2a4598c
 )

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/influxdata/influxdb v1.7.4
 	github.com/influxdata/platform v0.0.0-20190117200541-d500d3cf5589 // indirect
 	github.com/iovisor/gobpf v0.0.0-20190311163924-89fd87167a6e
-	github.com/jsimonetti/rtnetlink v0.0.0-20190606172950-9527aa82566a
+	github.com/jsimonetti/rtnetlink v0.0.0-20191203001355-5d027701a5b7
 	github.com/lorenzosaino/go-sysctl v0.1.0
 	github.com/magefile/mage v1.8.0
 	github.com/mdlayher/netlink v0.0.0-20191009155606-de872b0d824b

--- a/go.sum
+++ b/go.sum
@@ -117,6 +117,8 @@ github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4r
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
+github.com/google/nftables v0.0.0-20191115091743-3ba45f5d7848 h1:pd52J7uss/jDgGbQVc73QdoEZ0cR4ft+cEjPbaM4gBE=
+github.com/google/nftables v0.0.0-20191115091743-3ba45f5d7848/go.mod h1:cfspEyr/Ap+JDIITA+N9a0ernqG0qZ4W1aqMRgDZa1g=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/goreleaser/goreleaser v0.94.0/go.mod h1:OjbYR2NhOI6AEUWCowMSBzo9nP1aRif3sYtx+rhp+Zo=
@@ -175,6 +177,8 @@ github.com/jefferai/jsonx v0.0.0-20160721235117-9cc31c3135ee/go.mod h1:N0t2vlmpe
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
+github.com/jsimonetti/rtnetlink v0.0.0-20190606172950-9527aa82566a h1:84IpUNXj4mCR9CuCEvSiCArMbzr/TMbuPIadKDwypkI=
+github.com/jsimonetti/rtnetlink v0.0.0-20190606172950-9527aa82566a/go.mod h1:Oz+70psSo5OFh8DBl0Zv2ACw7Esh6pPUphlvZG9x7uw=
 github.com/jsternberg/zap-logfmt v1.2.0/go.mod h1:kz+1CUmCutPWABnNkOu9hOHKdT2q3TDYCcsFy9hpqb0=
 github.com/jtolds/gls v4.2.1+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
@@ -184,6 +188,8 @@ github.com/kevinburke/go-bindata v3.11.0+incompatible/go.mod h1:/pEEZ72flUW2p0yi
 github.com/kevinburke/ssh_config v0.0.0-20180830205328-81db2a75821e/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 github.com/keybase/go-crypto v0.0.0-20181031135447-f919bfda4fc1/go.mod h1:ghbZscTyKdM07+Fw3KSi0hcJm+AlEUWj8QLlPtijN/M=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/koneu/natend v0.0.0-20150829182554-ec0926ea948d h1:MFX8DxRnKMY/2M3H61iSsVbo/n3h0MWGmWNN1UViOU0=
+github.com/koneu/natend v0.0.0-20150829182554-ec0926ea948d/go.mod h1:QHb4k4cr1fQikUahfcRVPcEXiUgFsdIstGqlurL0XL4=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
@@ -208,6 +214,9 @@ github.com/mattn/go-tty v0.0.0-20180907095812-13ff1204f104/go.mod h1:XPvLUNfbS4f
 github.com/mattn/go-zglob v0.0.0-20171230104132-4959821b4817/go.mod h1:9fxibJccNxU2cnpIKLRRFA7zX7qhkJIQWBb449FYHOo=
 github.com/mattn/go-zglob v0.0.0-20180803001819-2ea3427bfa53/go.mod h1:9fxibJccNxU2cnpIKLRRFA7zX7qhkJIQWBb449FYHOo=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
+github.com/mdlayher/netlink v0.0.0-20190409211403-11939a169225/go.mod h1:eQB3mZE4aiYnlUsyGGCOpPETfdQq4Jhsgf1fk3cwQaA=
+github.com/mdlayher/netlink v0.0.0-20191009155606-de872b0d824b h1:W3er9pI7mt2gOqOWzwvx20iJ8Akiqz1mUMTxU6wdvl8=
+github.com/mdlayher/netlink v0.0.0-20191009155606-de872b0d824b/go.mod h1:KxeJAFOFLG6AjpyDkQ/iIhxygIUKD+vcwqcnu43w/+M=
 github.com/miekg/dns v1.1.1/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
 github.com/mitchellh/go-homedir v1.0.0 h1:vKb8ShqSby24Yrqr/yDYkuFz8d0WUjys40rvnGC8aR0=
@@ -309,6 +318,9 @@ github.com/tinylib/msgp v1.0.2/go.mod h1:+d+yLhGm8mzTaHzB+wgMYrodPfmZrzkirds8fDW
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/tylerb/graceful v1.2.15/go.mod h1:LPYTbOYmUTdabwRt0TGhLllQ0MUNbs0Y5q1WXJOI9II=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
+github.com/vishvananda/netns v0.0.0-20180720170159-13995c7128cc/go.mod h1:ZjcWmFBXmLKZu9Nxj3WKYEafiSqer2rnvPr0en9UNpI=
+github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df h1:OviZH7qLw/7ZovXvuNyL3XQl8UFofeikI1NW1Gypu7k=
+github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
 github.com/willf/bitset v1.1.9/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
 github.com/xanzy/ssh-agent v0.2.0/go.mod h1:0NyE30eGUDliuLEHJgYte/zncp2zdTStcOnWhgSqHD8=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
@@ -345,6 +357,10 @@ golang.org/x/net v0.0.0-20190125091013-d26f9f9a57f3/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297 h1:k7pJ2yAPLPgbskkFdhRCsA77k2fySZ1zf2zCjvQCiIM=
+golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20191028085509-fe3aa8a45271 h1:N66aaryRB3Ax92gH0v3hp1QYZ3zWWCCUR/j8Ifh45Ss=
+golang.org/x/net v0.0.0-20191028085509-fe3aa8a45271/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181017192945-9dcd33a902f4 h1:99CA0JJbUX4ozCnLon680Jc9e0T1i8HCaLVJMwtI8Hc=
 golang.org/x/oauth2 v0.0.0-20181017192945-9dcd33a902f4/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -366,8 +382,14 @@ golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a h1:1n5lsVfiQW3yfsRGu98756EH1YthsFqr/5mxHduZW2A=
 golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190411185658-b44545bcd369/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190502145724-3ef323f4f1fd h1:r7DufRZuZbWB7j439YfAzP8RPDa9unLkpwQKUYbIMPI=
 golang.org/x/sys v0.0.0-20190502145724-3ef323f4f1fd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456 h1:ng0gs1AKnRRuEMZoTLLlbOd+C17zUDepwGQBb/n+JVg=
+golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191029155521-f43be2a4598c h1:S/FtSvpNLtFBgjTqcKsRpsa6aVsI6iztaz1bQd9BJwE=
+golang.org/x/sys v0.0.0-20191029155521-f43be2a4598c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=

--- a/go.sum
+++ b/go.sum
@@ -177,8 +177,9 @@ github.com/jefferai/jsonx v0.0.0-20160721235117-9cc31c3135ee/go.mod h1:N0t2vlmpe
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
-github.com/jsimonetti/rtnetlink v0.0.0-20190606172950-9527aa82566a h1:84IpUNXj4mCR9CuCEvSiCArMbzr/TMbuPIadKDwypkI=
 github.com/jsimonetti/rtnetlink v0.0.0-20190606172950-9527aa82566a/go.mod h1:Oz+70psSo5OFh8DBl0Zv2ACw7Esh6pPUphlvZG9x7uw=
+github.com/jsimonetti/rtnetlink v0.0.0-20191203001355-5d027701a5b7 h1:8mvt7/1Kjhp0Q3KoTPhh9Srcp/acaWZfK9MWmG+z2KU=
+github.com/jsimonetti/rtnetlink v0.0.0-20191203001355-5d027701a5b7/go.mod h1:jA+FtkQ4/SGYz0Nix1so2WXNe/KnqVVJEDGukExrlM8=
 github.com/jsternberg/zap-logfmt v1.2.0/go.mod h1:kz+1CUmCutPWABnNkOu9hOHKdT2q3TDYCcsFy9hpqb0=
 github.com/jtolds/gls v4.2.1+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
@@ -215,6 +216,7 @@ github.com/mattn/go-zglob v0.0.0-20171230104132-4959821b4817/go.mod h1:9fxibJccN
 github.com/mattn/go-zglob v0.0.0-20180803001819-2ea3427bfa53/go.mod h1:9fxibJccNxU2cnpIKLRRFA7zX7qhkJIQWBb449FYHOo=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mdlayher/netlink v0.0.0-20190409211403-11939a169225/go.mod h1:eQB3mZE4aiYnlUsyGGCOpPETfdQq4Jhsgf1fk3cwQaA=
+github.com/mdlayher/netlink v0.0.0-20191008140946-2a17fd90af51/go.mod h1:KxeJAFOFLG6AjpyDkQ/iIhxygIUKD+vcwqcnu43w/+M=
 github.com/mdlayher/netlink v0.0.0-20191009155606-de872b0d824b h1:W3er9pI7mt2gOqOWzwvx20iJ8Akiqz1mUMTxU6wdvl8=
 github.com/mdlayher/netlink v0.0.0-20191009155606-de872b0d824b/go.mod h1:KxeJAFOFLG6AjpyDkQ/iIhxygIUKD+vcwqcnu43w/+M=
 github.com/miekg/dns v1.1.1/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
@@ -359,6 +361,7 @@ golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297 h1:k7pJ2yAPLPgbskkFdhRCsA77k2fySZ1zf2zCjvQCiIM=
 golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20191007182048-72f939374954/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191028085509-fe3aa8a45271 h1:N66aaryRB3Ax92gH0v3hp1QYZ3zWWCCUR/j8Ifh45Ss=
 golang.org/x/net v0.0.0-20191028085509-fe3aa8a45271/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -388,6 +391,7 @@ golang.org/x/sys v0.0.0-20190502145724-3ef323f4f1fd h1:r7DufRZuZbWB7j439YfAzP8RP
 golang.org/x/sys v0.0.0-20190502145724-3ef323f4f1fd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456 h1:ng0gs1AKnRRuEMZoTLLlbOd+C17zUDepwGQBb/n+JVg=
 golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191008105621-543471e840be/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191029155521-f43be2a4598c h1:S/FtSvpNLtFBgjTqcKsRpsa6aVsI6iztaz1bQd9BJwE=
 golang.org/x/sys v0.0.0-20191029155521-f43be2a4598c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=

--- a/pkg/bpf/integration_test.go
+++ b/pkg/bpf/integration_test.go
@@ -3,24 +3,33 @@
 package bpf
 
 import (
-	"fmt"
+	"encoding/binary"
 	"log"
 	"net"
 	"os"
-	"syscall"
+	"runtime"
 	"testing"
 	"time"
 
+	"github.com/jsimonetti/rtnetlink"
+	"github.com/mdlayher/netlink"
 	"github.com/pkg/errors"
+	"golang.org/x/sys/unix"
+
+	"github.com/google/nftables"
+	"github.com/google/nftables/binaryutil"
+	"github.com/google/nftables/expr"
+	"github.com/vishvananda/netns"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"github.com/ti-mo/conntracct/pkg/udpecho"
-	"golang.org/x/sys/unix"
 )
 
 // Mock UDP server listen port.
 const (
-	udpServ = 1342
+	udpServ = 4444
 )
 
 var (
@@ -47,12 +56,6 @@ func TestMain(m *testing.M) {
 		},
 	}
 
-	// Set the required sysctl's for the probe to gather accounting data.
-	err = Sysctls(false)
-	if err != nil {
-		log.Fatal(err)
-	}
-
 	// Create and start the Probe.
 	acctProbe, err = NewProbe(cfg)
 	if err != nil {
@@ -63,17 +66,73 @@ func TestMain(m *testing.M) {
 	}
 	go errWorker(acctProbe.ErrChan())
 
-	// Create and start the localhost UDP listener.
-	c := udpecho.ListenAndEcho(1342)
-
 	// Run tests, save the return code.
 	rc := m.Run()
 
 	// Tear down resources.
-	acctProbe.Stop()
-	c.Close()
+	if err := acctProbe.Stop(); err != nil {
+		log.Fatal(err)
+	}
 
 	os.Exit(rc)
+}
+
+// prepareNetNS creates a Conn in a new network namespace to use for testing.
+// Returns the UDP server and client, the netns identifier and error, if any.
+func prepareNetNS(port uint16) (*udpecho.MockUDP, int, func(), error) {
+
+	// Lock the current goroutine to the OS thread.
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	// Get the current network namespace and
+	// return the thread to it before unlocking.
+	oldns, err := netns.Get()
+	if err != nil {
+		return nil, 0, nil, err
+	}
+	defer func() {
+		if err := netns.Set(oldns); err != nil {
+			log.Fatal(err)
+		}
+	}()
+
+	// Allocate new network namespace.
+	newns, err := netns.New()
+	if err != nil {
+		return nil, 0, nil, errors.Wrap(err, "creating network namespace")
+	}
+
+	// Set up network interfaces inside the new netns.
+	if err := setupInterface(newns); err != nil {
+		return nil, 0, nil, errors.Wrap(err, "setting up interfaces")
+	}
+
+	// Set up nftables rules inside network namespace.
+	if err := setupNFTables(port, newns); err != nil {
+		return nil, 0, nil, errors.Wrap(err, "setting up nftables")
+	}
+
+	// Set the required sysctl's for the probe to gather accounting data.
+	if err := Sysctls(false); err != nil {
+		return nil, 0, nil, errors.Wrap(err, "applying sysctl")
+	}
+
+	// Create UDP listener inside network namespace.
+	srv := udpecho.ListenAndEcho(port)
+
+	// Create UDP client inside network namespace.
+	client := udpecho.Dial(port)
+
+	// Closer function passed to the caller to conveniently
+	// close all resources.
+	closer := func() {
+		client.Close()
+		srv.Close()
+		newns.Close()
+	}
+
+	return &client, int(newns), closer, nil
 }
 
 // Checks if the first packet in a flow is logged, and that
@@ -83,16 +142,18 @@ func TestProbeFirstPacket(t *testing.T) {
 	// Create and register consumer.
 	ac, in := newUpdateConsumer(t)
 
-	// Create UDP client.
-	mc := udpecho.Dial(udpServ)
+	// Set up a new network namespace to run tests.
+	mc, _, cfn, err := prepareNetNS(udpServ)
+	require.NoError(t, err, "preparing netns")
+	defer cfn()
 
 	// Filter BPF Events based on client port.
 	out := filterSourcePort(in, mc.ClientPort())
 
 	mc.Ping(1)
 	ev, err := readTimeout(out, 5)
-	assert.EqualValues(t, 1, ev.PacketsOrig+ev.PacketsRet, ev.String())
 	require.NoError(t, err)
+	assert.EqualValues(t, 1, ev.PacketsOrig+ev.PacketsRet, ev.String())
 
 	// Send another ping, and expect it to not be logged.
 	// Further attempt(s) to read from the channel should time out.
@@ -114,8 +175,10 @@ func TestProbeCurve(t *testing.T) {
 	// Create and register consumer.
 	ac, in := newUpdateConsumer(t)
 
-	// Create UDP client.
-	mc := udpecho.Dial(udpServ)
+	// Set up a new network namespace to run tests.
+	mc, _, cfn, err := prepareNetNS(udpServ)
+	require.NoError(t, err, "preparing netns")
+	defer cfn()
 
 	// Filter BPF Events based on client port.
 	out := filterSourcePort(in, mc.ClientPort())
@@ -124,8 +187,8 @@ func TestProbeCurve(t *testing.T) {
 	mc.Ping(1)
 	// expect the first packet to be logged,
 	ev, err := readTimeout(out, 5)
-	assert.EqualValues(t, 1, ev.PacketsOrig+ev.PacketsRet, ev.String())
 	require.NoError(t, err)
+	assert.EqualValues(t, 1, ev.PacketsOrig+ev.PacketsRet, ev.String())
 	// and the response to be dropped.
 	ev, err = readTimeout(out, 1)
 	// This also means events are drained.
@@ -226,8 +289,10 @@ func TestProbeVerify(t *testing.T) {
 	// Create and register consumer.
 	ac, in := newUpdateConsumer(t)
 
-	// Create UDP client.
-	mc := udpecho.Dial(udpServ)
+	// Set up a new network namespace to run tests.
+	mc, ns, cfn, err := prepareNetNS(udpServ)
+	require.NoError(t, err, "preparing netns")
+	defer cfn()
 
 	// Filter BPF Events based on client port.
 	out := filterSourcePort(in, mc.ClientPort())
@@ -237,9 +302,7 @@ func TestProbeVerify(t *testing.T) {
 	ev, err := readTimeout(out, 5)
 	require.NoError(t, err)
 
-	// Network Namespace
-	ns, err := getNSID()
-	require.NoError(t, err)
+	// Network namespace.
 	assert.EqualValues(t, ns, ev.NetNS, ev.String())
 
 	// Timestamp is always 0 on the first packet, since it passes
@@ -336,18 +399,213 @@ func newUpdateConsumer(t *testing.T) (*Consumer, chan Event) {
 	return ac, c
 }
 
-// getNSID gets the inode of the current process' network namespace.
-func getNSID() (uint64, error) {
-	path := fmt.Sprintf("/proc/%d/task/%d/ns/net", os.Getpid(), syscall.Gettid())
-	fd, err := unix.Open(path, syscall.O_RDONLY, 0)
+type CTState int
+
+const (
+	IPCTEstablished CTState = iota // IP_CT_ESTABLISHED
+	_                              // IP_CT_RELATED
+	IPCTNew                        // IP_CT_NEW
+)
+
+// ctStateBit replicates the behaviour of the NF_CT_STATE_BIT kernel macro.
+func ctStateBit(state CTState) uint32 {
+	return 1 << (uint32(state) + 1)
+}
+
+func setupNFTables(port uint16, ns netns.NsHandle) error {
+
+	nftc := nftables.Conn{
+		NetNS: int(ns),
+	}
+
+	nftc.FlushRuleset()
+
+	table := &nftables.Table{
+		Name:   "conntracct",
+		Family: nftables.TableFamily(unix.NFPROTO_INET),
+	}
+	nftc.AddTable(table)
+
+	policy := nftables.ChainPolicyDrop
+	chain := &nftables.Chain{
+		Name:     "ct_chain",
+		Table:    table,
+		Type:     nftables.ChainTypeFilter,
+		Hooknum:  nftables.ChainHookOutput,
+		Priority: nftables.ChainPriorityFilter,
+		Policy:   &policy,
+	}
+	nftc.AddChain(chain)
+
+	// Allow outgoing packets belonging to new and existing connections
+	// towards server port.
+	nftc.AddRule(&nftables.Rule{
+		Table: table,
+		Chain: chain,
+		Exprs: []expr.Any{
+
+			// UDP L4 Protocol
+			&expr.Meta{Key: expr.MetaKeyL4PROTO, Register: 1},
+			&expr.Cmp{
+				Op:       expr.CmpOpEq,
+				Register: 1,
+				Data:     []byte{unix.IPPROTO_UDP},
+			},
+
+			// UDP Destination Port
+			&expr.Payload{
+				Base:         expr.PayloadBaseTransportHeader,
+				Offset:       2, // destination port
+				Len:          2,
+				DestRegister: 1,
+			},
+			&expr.Cmp{
+				Op:       expr.CmpOpEq,
+				Register: 1,
+				Data:     binaryutil.BigEndian.PutUint16(port),
+			},
+
+			// New connections.
+			&expr.Ct{
+				Key:      expr.CtKeySTATE,
+				Register: 1,
+			},
+			&expr.Bitwise{
+				SourceRegister: 1,
+				DestRegister:   1,
+				Len:            4,
+				Mask:           binaryutil.NativeEndian.PutUint32(ctStateBit(IPCTNew) | ctStateBit(IPCTEstablished)),
+				Xor:            []uint8{0x0, 0x0, 0x0, 0x0},
+			},
+			&expr.Cmp{
+				Register: 1,
+				Op:       expr.CmpOpNeq,
+				Data:     []uint8{0x0, 0x0, 0x0, 0x0},
+			},
+
+			&expr.Verdict{
+				Kind: expr.VerdictAccept,
+			},
+		},
+	})
+
+	// Allow outgoing return packets belonging to
+	// existing connections from server port.
+	nftc.AddRule(&nftables.Rule{
+		Table: table,
+		Chain: chain,
+		Exprs: []expr.Any{
+
+			// UDP L4 Protocol
+			&expr.Meta{Key: expr.MetaKeyL4PROTO, Register: 1},
+			&expr.Cmp{
+				Op:       expr.CmpOpEq,
+				Register: 1,
+				Data:     []byte{unix.IPPROTO_UDP},
+			},
+
+			// UDP Source Port
+			&expr.Payload{
+				Base:         expr.PayloadBaseTransportHeader,
+				Offset:       0, // source port
+				Len:          2,
+				DestRegister: 1,
+			},
+			&expr.Cmp{
+				Op:       expr.CmpOpEq,
+				Register: 1,
+				Data:     binaryutil.BigEndian.PutUint16(port),
+			},
+
+			// Established connections.
+			&expr.Ct{
+				Key:      expr.CtKeySTATE,
+				Register: 1,
+			},
+			&expr.Bitwise{
+				SourceRegister: 1,
+				DestRegister:   1,
+				Len:            4,
+				Mask:           binaryutil.NativeEndian.PutUint32(ctStateBit(IPCTEstablished)),
+				Xor:            []uint8{0x0, 0x0, 0x0, 0x0},
+			},
+			&expr.Cmp{
+				Register: 1,
+				Op:       expr.CmpOpNeq,
+				Data:     []uint8{0x0, 0x0, 0x0, 0x0},
+			},
+
+			&expr.Verdict{
+				Kind: expr.VerdictAccept,
+			},
+		},
+	})
+
+	if err := nftc.Flush(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func setupInterface(ns netns.NsHandle) error {
+
+	// Gather the interface Index
+	iface, _ := net.InterfaceByName("lo")
+	// Get an ip address to add to the interface
+	addr, cidr, _ := net.ParseCIDR("127.0.0.1/8")
+
+	// Dial a connection to the rtnetlink socket.
+	cfg := netlink.Config{
+		NetNS: int(ns),
+	}
+	conn, err := rtnetlink.Dial(&cfg)
 	if err != nil {
-		return 0, err
+		return err
+	}
+	defer conn.Close()
+
+	// Test for the right cidress family for cidr
+	family := unix.AF_INET6
+	to4 := cidr.IP.To4()
+	if to4 != nil {
+		family = unix.AF_INET
+	}
+	// Calculate the prefix length
+	ones, _ := cidr.Mask.Size()
+
+	// Calculate the broadcast IP
+	// Only used when family is AF_INET
+	var brd net.IP
+	if to4 != nil {
+		brd = make(net.IP, len(to4))
+		binary.BigEndian.PutUint32(brd, binary.BigEndian.Uint32(to4)|^binary.BigEndian.Uint32(net.IP(cidr.Mask).To4()))
 	}
 
-	var s unix.Stat_t
-	if err := unix.Fstat(fd, &s); err != nil {
-		return 0, err
+	// Send the message using the rtnetlink.Conn
+	err = conn.Address.New(&rtnetlink.AddressMessage{
+		Family:       uint8(family),
+		PrefixLength: uint8(ones),
+		Scope:        unix.RT_SCOPE_UNIVERSE,
+		Index:        uint32(iface.Index),
+		Attributes: rtnetlink.AddressAttributes{
+			Address:   addr,
+			Local:     addr,
+			Broadcast: brd,
+		},
+	})
+	if err != nil {
+		return err
 	}
 
-	return s.Ino, nil
+	err = conn.Link.Set(&rtnetlink.LinkMessage{
+		Index:  uint32(iface.Index),
+		Flags:  unix.IFF_UP,
+		Change: unix.IFF_UP,
+	})
+	if err != nil {
+		return err
+	}
+
+	return err
 }

--- a/pkg/udpecho/client.go
+++ b/pkg/udpecho/client.go
@@ -1,9 +1,9 @@
 package udpecho
 
 import (
+	"fmt"
 	"log"
 	"net"
-	"strconv"
 	"time"
 )
 
@@ -21,9 +21,14 @@ type MockUDP struct {
 
 // Dial opens a UDP socket to the given port on localhost.
 // Returns a new MockUDP.
-func Dial(port uint16) MockUDP {
+// When host is an empty string, connects to 127.0.1.1 by default.
+func Dial(host string, port uint16) MockUDP {
 
-	dst, err := net.ResolveUDPAddr("udp", "localhost:"+strconv.Itoa(int(port)))
+	if host == "" {
+		host = "127.0.1.1"
+	}
+
+	dst, err := net.ResolveUDPAddr("udp", fmt.Sprintf("%s:%d", host, port))
 	if err != nil {
 		log.Fatalln("error resolving UDP address:", err)
 	}

--- a/pkg/udpecho/server.go
+++ b/pkg/udpecho/server.go
@@ -1,16 +1,21 @@
 package udpecho
 
 import (
+	"fmt"
 	"log"
 	"net"
-	"strconv"
 )
 
 // ListenAndEcho starts a UDP listener that replies 'pong'
 // in response to a request packet containing 'ping'.
-func ListenAndEcho(port uint16) net.PacketConn {
+// When host is an empty string, listens on 127.0.1.1 by default.
+func ListenAndEcho(host string, port uint16) net.PacketConn {
 
-	l, err := net.ListenPacket("udp4", "localhost:"+strconv.Itoa(int(port)))
+	if host == "" {
+		host = "127.0.1.1"
+	}
+
+	l, err := net.ListenPacket("udp4", fmt.Sprintf("%s:%d", host, port))
 	if err != nil {
 		log.Fatalln("error opening UDP listener:", err)
 	}


### PR DESCRIPTION
Sets up the following objects in network namespaces:
- simple nftables ruleset for enabling conntracking
- `127.0.1.1` on `lo`
- udpecho server and client