### PR TITLE
integration - remove explicit nf_conntrack modprobe

### DIFF
--- a/magefile-integration.go
+++ b/magefile-integration.go
@@ -21,21 +21,11 @@ const (
 func (Integration) Test() error {
 
 	testArgs := []string{"test", "-v", "-race", "-coverprofile=" + intCov, "-covermode=atomic", "-tags=integration", "./..."}
-
-	modprobeCmd := "modprobe"
-	modprobeArgs := []string{"-aq", "xt_conntrack", "nf_conntrack", "nf_conntrack_ipv4", "nf_conntrack_ipv6"}
-
 	// Execute with sudo when the current UID is not 0.
 	if u, _ := user.Current(); u.Uid != "0" {
 		fmt.Println("Not running with uid 0, using sudo to run integration tests.")
 		testArgs = append(testArgs, "-exec=sudo")
-
-		modprobeCmd = "sudo"
-		modprobeArgs = append([]string{"modprobe"}, modprobeArgs...)
 	}
-
-	// Modprobe might fail due to missing modules on some systems, ignore.
-	sh.RunV(modprobeCmd, modprobeArgs...)
 
 	if err := sh.RunV("go", testArgs...); err != nil {
 		return err

--- a/pkg/bpf/integration_test.go
+++ b/pkg/bpf/integration_test.go
@@ -56,7 +56,18 @@ func TestMain(m *testing.M) {
 		},
 	}
 
+	// Set up a dummy network namespace and immediately close it.
+	// One of the steps of preparing a namespace includes installing an nftables ruleset.
+	// This ruleset contains a conntrack matcher, which will automatically cause the correct
+	// conntrack kernel module to be loaded. This means we don't have to explicitly modprobe.
+	_, _, f, err := prepareNetNS(9999)
+	f()
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	// Create and start the Probe.
+	// For this to succeed, a conntrack kernel module needs to have been pre-loaded.
 	acctProbe, err = NewProbe(cfg)
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
Set up a dummy netns before trying to attach the kprobe.

Installing an nftables rule that contains a conntrack matcher obviates the need for explicitly modprobing one of many possible `nf_/ct_/xt_/...conntrack` kernel modules.