### PR TITLE
config - fix behaviour of sourcePorts flag on influxdb sink

### DIFF
--- a/configs/conntracct.yml
+++ b/configs/conntracct.yml
@@ -30,7 +30,7 @@ sinks:
     type: influxdb-udp
     address: "localhost:8089"
     batchSize: 200
-    sourcePorts: false
+    # sourcePorts: false   # (default: false) log connections' (usually-)random source ports
     # udpPayloadSize: 512  # (default: 512) only change this on local networks within MTU
 
   influxdb_http:
@@ -38,7 +38,7 @@ sinks:
     address: "http://localhost:8086"
     database: conntracct_http
     batchSize: 200
-    sourcePorts: false
+    # sourcePorts: false
 
   elastic:
     type: elastic

--- a/internal/config/sink.go
+++ b/internal/config/sink.go
@@ -13,9 +13,9 @@ import (
 // DefaultSinkConfig is the default sink configuration.
 var DefaultSinkConfig = []SinkConfig{
 	{
-		Name:          "stdout",
-		Type:          types.StdOut,
-		EnableSrcPort: true,
+		Name:        "stdout",
+		Type:        types.StdOut,
+		SourcePorts: true,
 	},
 }
 
@@ -32,7 +32,7 @@ type SinkConfig struct {
 	Type types.SinkType `mapstructure:"type"`
 
 	// Whether or not the sink should receive the flows' source ports.
-	EnableSrcPort bool `mapstructure:"enableSrcPort"`
+	SourcePorts bool `mapstructure:"sourcePorts"`
 
 	// Name of the sink.
 	Name string `mapstructure:"-"`

--- a/internal/sinks/influxdb/influxdb.go
+++ b/internal/sinks/influxdb/influxdb.go
@@ -160,7 +160,7 @@ func (s *InfluxSink) push(e bpf.Event) {
 	}
 
 	// Optionally set flows' source ports (since they're random in most cases)
-	if s.config.EnableSrcPort {
+	if s.config.SourcePorts {
 		tags["src_port"] = strconv.FormatUint(uint64(e.SrcPort), 10)
 	}
 


### PR DESCRIPTION
The default configuration did not match the actual `mapstructure` struct tag, and the flag was therefore ignored. I carved out the sink configuration parser into the `internal/config` package in a previous PR so this can be more easily unit tested.

@markpash