### PR TITLE
Recalculate boot time offset periodically

### DIFF
--- a/internal/sinks/elasticsearch/elastic.go
+++ b/internal/sinks/elasticsearch/elastic.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/ti-mo/conntracct/internal/config"
 	"github.com/ti-mo/conntracct/internal/sinks/types"
-	"github.com/ti-mo/conntracct/pkg/boottime"
 	"github.com/ti-mo/conntracct/pkg/bpf"
 )
 
@@ -24,9 +23,6 @@ type ElasticSink struct {
 
 	// Sink's configuration object.
 	config config.SinkConfig
-
-	// Estimated boot time of the machine.
-	bootTime time.Time
 
 	// elastic driver client handle.
 	client *elastic.Client
@@ -75,10 +71,6 @@ func (s *ElasticSink) Init(sc config.SinkConfig) error {
 
 	s.config = sc
 	s.client = client
-
-	// Estimate the machine's boot time, for absolute event timestamps.
-	// TODO(timo): Make this automatically refresh every x seconds.
-	s.bootTime = boottime.Estimate()
 
 	// Install index templates (mapping and shard/replica settings).
 	if err := s.installMappings(sc.Database); err != nil {

--- a/internal/sinks/elasticsearch/event.go
+++ b/internal/sinks/elasticsearch/event.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/ti-mo/conntracct/internal/sinks/helpers"
+	"github.com/ti-mo/conntracct/pkg/boottime"
 	"github.com/ti-mo/conntracct/pkg/bpf"
 )
 
@@ -41,7 +42,7 @@ func (s *ElasticSink) transformEvent(e *event) {
 	e.Start = e.Start / uint64(time.Millisecond)
 
 	// Apply boot time offset to the (relative) event timestamp, convert to milliseconds.
-	e.Timestamp = uint64(s.bootTime.Add(time.Duration(e.Timestamp)).UnixNano() / int64(time.Millisecond))
+	e.Timestamp = uint64(boottime.Absolute(int64(e.Timestamp)) / int64(time.Millisecond))
 
 	// Calculated fields.
 	e.PacketsTotal = e.PacketsOrig + e.PacketsRet

--- a/pkg/boottime/boottime.go
+++ b/pkg/boottime/boottime.go
@@ -2,12 +2,28 @@ package boottime
 
 import (
 	"runtime"
+	"sync/atomic"
 	"time"
 	_ "unsafe" // required for go:linkname
 )
 
-// Amount of times to call nanotime() + time.Now().
-const rounds = 15
+const (
+	// Amount of times to call nanotime() + time.Now().
+	rounds = 10
+
+	// Seconds between polling cycles.
+	interval = 2
+)
+
+var nanos int64
+
+func init() {
+	// Ensure a valid timestamp has been estimated on init.
+	storeNanos(estimate())
+
+	// Start the background worker.
+	go worker()
+}
 
 //go:noescape
 //go:linkname nanotime runtime.nanotime
@@ -24,31 +40,74 @@ func nanotime() int64
 // the nanotime from the time.Now() value. Each round, the result is
 // 'voted' on, to increase the confidence in the origin timestamp.
 func Estimate() time.Time {
+	return time.Unix(0, estimate())
+}
 
-	t := make(map[time.Time]uint8)
+// Absolute converts a relative nanosecond-resolution timestamp t to
+// an absolute timestamp. An example of a relative timestamp is a timestamp
+// obtained from eBPF's ktime_get_ns.
+func Absolute(t int64) int64 {
+	return getNanos() + t
+}
+
+// estimate spawns a locked OS thread to call nanotime() and time.Now()
+// in a tight loop. On each sample, the nanotime is subtracted from the absolute
+// timestamp, and the resulting value is voted on.
+func estimate() int64 {
+	t := make(map[int64]uint8)
+	var b int64
 
 	// Lock the goroutine to an OS thread so it doesn't
 	// get de-scheduled. We want the nanotime() and time.Now()
 	// calls to occur as close to each other as possible.
 	runtime.LockOSThread()
 	for i := 0; i < rounds; i++ {
+
+		// Get relative and absolute timestamps.
 		ns := nanotime()
 		now := time.Now()
-		bootTime := now.Add(-time.Duration(ns))
-		t[bootTime]++ // vote on the obtained bootTime
+
+		// Approximate the boot time.
+		b = now.Add(-time.Duration(ns)).UnixNano()
+
+		// Vote on the obtained boot time.
+		t[b]++
 	}
 	runtime.UnlockOSThread()
 
-	var out time.Time
+	var out int64
 	var max uint8
 
 	// Find the most voted-on Time entry in the map.
 	for ts, n := range t {
 		if n > max {
-			out = ts
+			// Bump the maximum result.
 			max = n
+			// Hold on to the key.
+			out = ts
 		}
 	}
 
 	return out
+}
+
+// storeNanos atomically stores t in the package-global timestamp.
+func storeNanos(t int64) {
+	atomic.StoreInt64(&nanos, t)
+}
+
+// getNanos atomically loads the package-global timestamp.
+func getNanos() int64 {
+	return atomic.LoadInt64(&nanos)
+}
+
+// worker updates the package-global timestamp every interval seconds.
+func worker() {
+	t := time.NewTicker(interval * time.Second)
+	defer t.Stop()
+
+	for {
+		<-t.C
+		storeNanos(estimate())
+	}
 }

--- a/pkg/boottime/boottime_test.go
+++ b/pkg/boottime/boottime_test.go
@@ -1,0 +1,44 @@
+package boottime
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	window = 10 * time.Millisecond
+)
+
+func TestEstimate(t *testing.T) {
+	// Estimate the boot time.
+	e := Estimate()
+
+	// Boot time should be before now.
+	assert.True(t, e.Before(time.Now()))
+
+	// Add the current monotonic clock to the estimated boot time.
+	aboutNow := e.Add(time.Duration(nanotime()))
+
+	// Check if the timestamp is within an offset from time.Now().
+	testWindow(t, aboutNow, window)
+}
+
+func TestAbsolute(t *testing.T) {
+	// Convert nanotime to an absolute timestamp and assert it falls within the window.
+	testWindow(t, time.Unix(0, Absolute(nanotime())), window)
+}
+
+// testWindow tests if ts falls between time.Now() plus and minus w.
+func testWindow(t *testing.T, ts time.Time, w time.Duration) {
+
+	now := time.Now()
+	past := now.Add(-w)
+	future := now.Add(w)
+
+	// Timestamp should not be longer ago than the window size.
+	assert.True(t, ts.After(past))
+	// It should not be farther into the future than the window size.
+	assert.True(t, ts.Before(future))
+}


### PR DESCRIPTION
Closes #9.

I opted for a periodic (currently every 2s) recalculation of the boot time offset. The offset itself should later be exported as a Prometheus metric, when that is implemented.