### PR TITLE
pkg/bpf - FlowID field with blake3 flow hash

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,4 +27,5 @@ require (
 	github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df
 	golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6
 	golang.org/x/sys v0.0.0-20191029155521-f43be2a4598c
+	lukechampine.com/blake3 v0.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -449,3 +449,5 @@ gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20181108184350-ae8f1f9103cc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
+lukechampine.com/blake3 v0.4.0 h1:XvkyUJ2cS516FbLIconKg2TFK9WyeadiMXbo/iWDuUU=
+lukechampine.com/blake3 v0.4.0/go.mod h1:e0XQzEQp6LtbXBhzYxRoh6s3kcmX+fMMg8sC9VgWloQ=

--- a/internal/sinks/elasticsearch/templates.go
+++ b/internal/sinks/elasticsearch/templates.go
@@ -26,7 +26,7 @@ func (s *ElasticSink) installMappings(db string) error {
 				"packets_orig": { "type":"long" },
 				"packets_ret": { "type":"long" },
 				"packets_total": { "type":"long" }, // Calculated field.
-				"connection_id": { "type":"long" },
+				"flow_id": { "type":"long" },
 				"connmark": { "type":"integer" },
 				"src_addr": { "type":"ip" },
 				"src_port": { "type":"integer" },

--- a/internal/sinks/influxdb/influxdb.go
+++ b/internal/sinks/influxdb/influxdb.go
@@ -144,7 +144,7 @@ func (s *InfluxSink) push(e bpf.Event) {
 
 	// Create a point and add to batch.
 	tags := map[string]string{
-		"conn_id":  strconv.FormatUint(uint64(e.ConnectionID), 10),
+		"flow_id":  strconv.FormatUint(e.FlowID, 10),
 		"src_addr": e.SrcAddr.String(),
 		"dst_addr": e.DstAddr.String(),
 		"dst_port": strconv.FormatUint(uint64(e.DstPort), 10),
@@ -163,8 +163,8 @@ func (s *InfluxSink) push(e bpf.Event) {
 	// though the current version (1.6) has this behind a build flag as it's not yet
 	// generally available. Only send signed ints for now until this is more widely deployed.
 	fields := map[string]interface{}{
-		// Include conn_id in both fields and tags so it can be used in both aggregations and selections.
-		"conn_id":       strconv.FormatUint(uint64(e.ConnectionID), 10),
+		// Include flow_id in both fields and tags so it can be used in both aggregations and selections.
+		"flow_id":       strconv.FormatUint(e.FlowID, 10),
 		"bytes_orig":    int64(e.BytesOrig),
 		"bytes_ret":     int64(e.BytesRet),
 		"bytes_total":   int64(e.BytesOrig + e.BytesRet),

--- a/pkg/bpf/event.go
+++ b/pkg/bpf/event.go
@@ -3,6 +3,7 @@ package bpf
 import (
 	"encoding/binary"
 	"fmt"
+	"hash"
 	"net"
 	"unsafe"
 )
@@ -12,25 +13,27 @@ const EventLength = 104
 
 // Event is an accounting event delivered to userspace from the Probe.
 type Event struct {
-	Start        uint64 `json:"start"`     // epoch timestamp of flow start
-	Timestamp    uint64 `json:"timestamp"` // ktime of event, relative to machine boot time
-	ConnectionID uint32 `json:"connection_id"`
-	Connmark     uint32 `json:"connmark"`
-	SrcAddr      net.IP `json:"src_addr"`
-	DstAddr      net.IP `json:"dst_addr"`
-	PacketsOrig  uint64 `json:"packets_orig"`
-	BytesOrig    uint64 `json:"bytes_orig"`
-	PacketsRet   uint64 `json:"packets_ret"`
-	BytesRet     uint64 `json:"bytes_ret"`
-	SrcPort      uint16 `json:"src_port"`
-	DstPort      uint16 `json:"dst_port"`
-	NetNS        uint32 `json:"netns"`
-	Proto        uint8  `json:"proto"`
+	Start       uint64 `json:"start"`     // epoch timestamp of flow start
+	Timestamp   uint64 `json:"timestamp"` // ktime of event, relative to machine boot time
+	FlowID      uint64 `json:"flow_id"`
+	Connmark    uint32 `json:"connmark"`
+	SrcAddr     net.IP `json:"src_addr"`
+	DstAddr     net.IP `json:"dst_addr"`
+	PacketsOrig uint64 `json:"packets_orig"`
+	BytesOrig   uint64 `json:"bytes_orig"`
+	PacketsRet  uint64 `json:"packets_ret"`
+	BytesRet    uint64 `json:"bytes_ret"`
+	SrcPort     uint16 `json:"src_port"`
+	DstPort     uint16 `json:"dst_port"`
+	NetNS       uint32 `json:"netns"`
+	Proto       uint8  `json:"proto"`
+
+	connectionID uint32
 }
 
-// UnmarshalBinary unmarshals a binary Event representation
-// into a struct, using the machine's native endianness.
-func (e *Event) UnmarshalBinary(b []byte) error {
+// unmarshalBinary unmarshals a slice of bytes received from the
+// kernel's eBPF perf map into a struct using the machine's native endianness.
+func (e *Event) unmarshalBinary(b []byte) error {
 
 	if len(b) != EventLength {
 		return fmt.Errorf("input byte array incorrect length %d", len(b))
@@ -38,7 +41,7 @@ func (e *Event) UnmarshalBinary(b []byte) error {
 
 	e.Start = *(*uint64)(unsafe.Pointer(&b[0]))
 	e.Timestamp = *(*uint64)(unsafe.Pointer(&b[8]))
-	e.ConnectionID = *(*uint32)(unsafe.Pointer(&b[16]))
+	e.connectionID = *(*uint32)(unsafe.Pointer(&b[16]))
 	e.Connmark = *(*uint32)(unsafe.Pointer(&b[20]))
 
 	// Build an IPv4 address if only the first four bytes
@@ -72,6 +75,41 @@ func (e *Event) UnmarshalBinary(b []byte) error {
 	e.NetNS = *(*uint32)(unsafe.Pointer(&b[92]))
 
 	return nil
+}
+
+// hashFlow appends the Event's source and destination address,
+// ports, protocol and connection ID, calculates the hash,
+// sets the Event's FlowID and resets the Hasher.
+func (e *Event) hashFlow(h hash.Hash) {
+
+	// Source/Destination Address.
+	_, _ = h.Write(e.SrcAddr)
+	_, _ = h.Write(e.DstAddr)
+
+	b := make([]byte, 2)
+
+	// Source Port.
+	binary.BigEndian.PutUint16(b, e.SrcPort)
+	_, _ = h.Write(b)
+
+	// Destination Port.
+	binary.BigEndian.PutUint16(b, e.DstPort)
+	_, _ = h.Write(b)
+
+	// Protocol.
+	_, _ = h.Write([]byte{e.Proto})
+
+	b = make([]byte, 4)
+
+	// Connection ID.
+	binary.BigEndian.PutUint32(b, e.connectionID)
+	_, _ = h.Write(b)
+
+	// Calculate the hash and reset the Hasher.
+	// Shift one position to the right to fit the FlowID into a
+	// (signed) long, eg. in elasticsearch.
+	e.FlowID = binary.LittleEndian.Uint64(h.Sum(nil)) >> 1
+	h.Reset()
 }
 
 // String returns a readable string representation of the Event.

--- a/pkg/bpf/event_test.go
+++ b/pkg/bpf/event_test.go
@@ -1,0 +1,27 @@
+package bpf
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"lukechampine.com/blake3"
+)
+
+func TestHashFlow(t *testing.T) {
+
+	h := blake3.New(8, nil)
+
+	e := Event{
+		SrcAddr:      net.ParseIP("1.2.3.4"),
+		DstAddr:      net.ParseIP("5.6.7.8"),
+		SrcPort:      1234,
+		DstPort:      5678,
+		Proto:        6,
+		connectionID: 11111111,
+	}
+
+	e.hashFlow(h)
+
+	assert.Equal(t, uint64(0x557151a9a4846ab8), e.FlowID)
+}


### PR DESCRIPTION
I ran into a case in my environment where a `connection_id` value was recycled
for another connection immediately after being destroyed. This made it clear
that `connection_id` cannot safely be used as a sole flow identifier. Instead,
it was replaced with a `flow_id` field that takes source/destination addresses
and ports, the protocol and the connection_id and hashes it with Blake3.